### PR TITLE
Improve invoice wording and prescription output

### DIFF
--- a/pages/invoice.html
+++ b/pages/invoice.html
@@ -86,11 +86,11 @@
             <label for="invoiceDate">Date</label>
             <input id="invoiceDate" type="date" />
           </div>
-          <!-- Payer details: defaulted to doctor; edit if needed -->
+          <!-- Payer details -->
           <div class="form-row">
-            <label for="receivedFrom">Received with thanks from</label>
-            <input id="receivedFrom" required />
-            <span class="hint">This will default to the doctor’s name; you may edit if needed.</span>
+            <label for="receivedFrom">Received with Thanks from:</label>
+            <input id="receivedFrom" placeholder="Patient name" required />
+            <span class="hint">Enter the name of the person paying.</span>
           </div>
           <!-- Sum of Rs removed (PDF total is computed from items) -->
         </div>

--- a/pages/prescription.html
+++ b/pages/prescription.html
@@ -141,9 +141,9 @@
   set('p_bmi',    d.bmi);
 
   set('p_presentComplaint', d.presentComplaint);
-  // Prefix the past complaint and history of drugs text
-  set('p_pastComplaint',    d.pastComplaint ? `Past Complaint: ${d.pastComplaint}` : '');
-  set('p_hoDrugs',          d.hoDrugs ? `H/O taken drugs: ${d.hoDrugs}` : '');
+  // Prefix the past history and history of drugs text when provided
+  set('p_pastComplaint',    d.pastComplaint && d.pastComplaint.trim() ? `Past History: ${d.pastComplaint}` : '');
+  set('p_hoDrugs',          d.hoDrugs && d.hoDrugs.trim() ? `H/O taken drugs: ${d.hoDrugs}` : '');
 
   // Wait a tick so the background image sizes correctly, then open print
   window.onload = () => setTimeout(() => window.print(), 400);


### PR DESCRIPTION
## Summary
- Ensure invoice payee input defaults to patient name and updated label
- Append `Only` to amount-in-words and render it in bold on generated PDFs
- Hide empty past history/H.O fields on printed prescriptions
- Fix invoice PDF to a constant 3×5" layout with bold text and generous spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c0c1e9f08327867a8de36ad26521