### PR TITLE
feat: add signature space to invoices

### DIFF
--- a/js/invoice.js
+++ b/js/invoice.js
@@ -257,12 +257,13 @@
     doc.setFontSize(7);
     const itemsStartY = y;
     const itemsCount = (payload.items && payload.items.length) ? payload.items.length : 1;
+    const signatureGap = 20; // space reserved before the signature line
     const reservedHeight =
       4 + // space before totals
       6 + // "Sum of Rs" line
       6 + // "Rupees" line
       (wordsWrapped.length * 5) + // amount in words lines
-      6 + // space before signature
+      signatureGap + // space before signature
       8 + // signature line space
       6 + // clinic name
       (addrWrapped.length * 5); // address lines
@@ -301,7 +302,7 @@
     doc.setFontSize(8);
 
     // Signature line
-    y += 6;
+    y += signatureGap;
     const sigWidth = 32;
     const sigX = (pdfWidth - sigWidth) / 2;
     doc.setLineWidth(0.2);

--- a/js/receipt margins invoice.js
+++ b/js/receipt margins invoice.js
@@ -299,7 +299,8 @@
       doc.text(line, 75, yy, { align: 'right' });
       yy += 3;
     });
-    yy += 2;
+    const signatureGap = 12; // space before signature line
+    yy += signatureGap;
     // Signature line
     const sigLineWidth = 32;
     const sigX = (80 - sigLineWidth) / 2;

--- a/pages/receipt margins invoice.js
+++ b/pages/receipt margins invoice.js
@@ -299,7 +299,8 @@
       doc.text(line, 75, yy, { align: 'right' });
       yy += 3;
     });
-    yy += 2;
+    const signatureGap = 12; // space before signature line
+    yy += signatureGap;
     // Signature line
     const sigLineWidth = 32;
     const sigX = (80 - sigLineWidth) / 2;


### PR DESCRIPTION
## Summary
- reserve additional space before signature line on invoices
- keep layout dynamic for stamp or signature

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c67679788327a6b646b56d93abc7