### PR TITLE
feat: add prescription PDF download

### DIFF
--- a/pages/patient_form.html
+++ b/pages/patient_form.html
@@ -273,6 +273,7 @@
         <div class="form-actions">
           <button class="btn btn-success" type="submit">Save Patient</button>
           <button class="btn btn-ghost" type="reset">Reset</button>
+          <button type="button" id="downloadPrescription" class="btn btn-success">Download PDF</button>
           <button type="button" id="printPrescription" class="btn btn-outline">Print Prescription</button>
         </div>
 
@@ -285,6 +286,8 @@
     <small>© <span id="year"></span> Tulsi Care Clinic. All rights reserved.</small>
   </footer>
 
+  <!-- jsPDF for PDF generation -->
+  <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
   <!-- Load the patient form controller from the parent js folder -->
   <script src="../js/patient_form.js"></script>
 


### PR DESCRIPTION
## Summary
- add a Download PDF button alongside Print Prescription
- generate prescription PDF with jsPDF and clinic template without opening the print view

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c9dd96488327a90b22cab00ef9f4