### PR TITLE
Add patient editing workflow and invoice persistence

### DIFF
--- a/js/edit_patient.js
+++ b/js/edit_patient.js
@@ -1,0 +1,234 @@
+/**
+ * edit_patient.js
+ * Controller for editing existing patient records.
+ */
+(function () {
+  const y = document.getElementById('year');
+  if (y) y.textContent = new Date().getFullYear();
+
+  const form = document.getElementById('patientForm');
+  const msg  = document.getElementById('saveMsg');
+
+  const params = new URLSearchParams(window.location.search);
+  const refNo = params.get('refNo');
+  if (!refNo) {
+    alert('No patient reference provided.');
+    window.location.href = 'search.html';
+    return;
+  }
+
+  const refField = document.getElementById('refNo');
+  if (refField) {
+    refField.value = refNo;
+    refField.readOnly = true;
+  }
+
+  const el = (id) => document.getElementById(id);
+  const getVal = (id) => (el(id)?.value ?? '').trim();
+  const setVal = (id, v) => { const e = el(id); if (e) e.value = v ?? ''; };
+  const numOrNull = (v) => (v === '' ? null : Number(v));
+
+  // Initialise Supabase client
+  const SUPABASE_URL = 'https://dxypmfzpeeovghrzmmnq.supabase.co';
+  const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImR4eXBtZnpwZWVvdmdocnptbW5xIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTY0MjgwNzAsImV4cCI6MjA3MjAwNDA3MH0.MRuGQCxuSCSiemaRag3hUMftypgizDJQXLGpCdEmi8U';
+  let supabaseClient = null;
+  try {
+    if (window.supabaseClient) {
+      supabaseClient = window.supabaseClient;
+    } else if (window.supabase && typeof window.supabase.createClient === 'function') {
+      supabaseClient = window.supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
+    }
+  } catch (err) {
+    console.warn('Supabase client could not be initialised', err);
+  }
+
+  function getPatients() {
+    try { return JSON.parse(localStorage.getItem('patients_full') || '[]'); }
+    catch { return []; }
+  }
+  function setPatients(list) {
+    localStorage.setItem('patients_full', JSON.stringify(list));
+  }
+
+  async function loadPatient() {
+    let patient = null;
+    if (supabaseClient) {
+      try {
+        const { data, error } = await supabaseClient
+          .from('patients')
+          .select('*')
+          .eq('refNo', refNo)
+          .single();
+        if (!error) patient = data;
+      } catch (e) {
+        console.error('Error loading patient', e);
+      }
+    }
+    if (!patient) {
+      const list = getPatients();
+      patient = list.find(p => p.refNo === refNo) || null;
+    }
+    if (!patient) {
+      alert('Patient not found.');
+      return;
+    }
+    setVal('name', patient.name);
+    setVal('cast', patient.cast);
+    setVal('age', patient.age);
+    setVal('date', patient.date ? patient.date.split('T')[0] : '');
+    setVal('address', patient.address);
+    setVal('mobile', patient.mobile);
+
+    const labs = patient.labs || {};
+    setVal('fbs', labs.fbs);
+    setVal('rbs', labs.rbs);
+    setVal('bMealSugar', labs.bMealSugar);
+    setVal('bChol', labs.bChol);
+    setVal('ldl', labs.ldl);
+    setVal('tg', labs.tg);
+    setVal('hdl', labs.hdl);
+    setVal('bp', labs.bp);
+    setVal('sCreat', labs.sCreat);
+    setVal('sUric', labs.sUric);
+    setVal('bmi', labs.bmi);
+    setVal('spo2', labs.spo2);
+    setVal('pulse', labs.pulse);
+    setVal('weight', labs.weight);
+    setVal('temp', labs.temp);
+
+    const hist = patient.history || {};
+    setVal('dmAbove', hist.dm?.value);
+    setVal('dmUnit', hist.dm?.unit);
+    setVal('bpAbove', hist.bp?.value);
+    setVal('bpUnit', hist.bp?.unit);
+    setVal('psychAbove', hist.depressionFits?.value);
+    setVal('psychUnit', hist.depressionFits?.unit);
+    setVal('psychosisAbove', hist.psychosis?.value);
+    setVal('psychosisUnit', hist.psychosis?.unit);
+    setVal('ckdAbove', hist.ckd?.value);
+    setVal('ckdUnit', hist.ckd?.unit);
+    setVal('dfAbove', hist.diabeticFoot?.value);
+    setVal('dfUnit', hist.diabeticFoot?.unit);
+    setVal('others', hist.others);
+    if (hist.smoking) {
+      const r = document.querySelector(`input[name="smoke"][value="${hist.smoking}"]`);
+      if (r) r.checked = true;
+    }
+
+    const comp = patient.complaints || {};
+    setVal('presentComplaint', comp.present);
+    setVal('pastComplaint', comp.past);
+    setVal('hoDrugs', comp.hoDrugs);
+  }
+
+  loadPatient();
+
+  async function updatePatient(payload) {
+    if (!supabaseClient) return false;
+    try {
+      const { error } = await supabaseClient
+        .from('patients')
+        .update(payload)
+        .eq('refNo', refNo);
+      if (error) {
+        console.error('Error updating patient', error);
+        return false;
+      }
+      return true;
+    } catch (err) {
+      console.error('Unexpected error during Supabase update', err);
+      return false;
+    }
+  }
+
+  if (form) {
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const payload = {
+        name: getVal('name'),
+        cast: getVal('cast') || null,
+        age: numOrNull(getVal('age')),
+        date: getVal('date'),
+        address: getVal('address') || null,
+        mobile: getVal('mobile') || null,
+        labs: {
+          fbs: numOrNull(getVal('fbs')),
+          rbs: numOrNull(getVal('rbs')),
+          bMealSugar: numOrNull(getVal('bMealSugar')),
+          bChol: numOrNull(getVal('bChol')),
+          ldl: numOrNull(getVal('ldl')),
+          tg: numOrNull(getVal('tg')),
+          hdl: numOrNull(getVal('hdl')),
+          bp: getVal('bp') || null,
+          sCreat: numOrNull(getVal('sCreat')),
+          sUric: numOrNull(getVal('sUric')),
+          bmi: numOrNull(getVal('bmi')),
+          spo2: numOrNull(getVal('spo2')),
+          pulse: numOrNull(getVal('pulse')),
+          weight: numOrNull(getVal('weight')),
+          temp: getVal('temp') || null,
+        },
+        history: {
+          dm: { value: numOrNull(getVal('dmAbove')), unit: getVal('dmUnit') || null },
+          bp: { value: numOrNull(getVal('bpAbove')), unit: getVal('bpUnit') || null },
+          depressionFits: { value: numOrNull(getVal('psychAbove')), unit: getVal('psychUnit') || null },
+          psychosis: { value: numOrNull(getVal('psychosisAbove')), unit: getVal('psychosisUnit') || null },
+          ckd: { value: numOrNull(getVal('ckdAbove')), unit: getVal('ckdUnit') || null },
+          diabeticFoot: { value: numOrNull(getVal('dfAbove')), unit: getVal('dfUnit') || null },
+          others: getVal('others') || null,
+          smoking: (document.querySelector('input[name="smoke"]:checked')?.value) || null,
+        },
+        complaints: {
+          present: getVal('presentComplaint') || null,
+          past: getVal('pastComplaint') || null,
+          hoDrugs: getVal('hoDrugs') || null,
+        },
+        updatedAt: new Date().toISOString(),
+      };
+
+      let saved = false;
+      if (supabaseClient) {
+        saved = await updatePatient(payload);
+      }
+      if (!saved) {
+        const list = getPatients();
+        const idx = list.findIndex(p => p.refNo === refNo);
+        if (idx !== -1) {
+          list[idx] = { ...list[idx], ...payload, refNo };
+          setPatients(list);
+          saved = true;
+        }
+      }
+
+      if (saved && msg) {
+        msg.textContent = supabaseClient ? 'Patient updated in database.' : 'Patient updated locally (offline demo).';
+        msg.classList.remove('error'); msg.classList.add('ok');
+      }
+    });
+
+    form.addEventListener('reset', () => {
+      setTimeout(loadPatient, 0);
+    });
+  }
+
+  // Reuse print logic from patient_form.js
+  const printBtn = document.getElementById('printPrescription');
+  if (printBtn) {
+    printBtn.addEventListener('click', () => {
+      const ids = [
+        'refNo','date','name','age','cast','address','mobile',
+        'dmAbove','dmUnit','bpAbove','bpUnit','psychAbove','psychUnit',
+        'psychosisAbove','psychosisUnit','ckdAbove','ckdUnit','dfAbove','dfUnit',
+        'others','bp','pulse','temp','spo2','fbs','rbs','bMealSugar','bChol','ldl','tg','hdl',
+        'sCreat','sUric','bmi','weight','presentComplaint','pastComplaint','hoDrugs'
+      ];
+      const data = {};
+      ids.forEach(id => data[id] = (document.getElementById(id)?.value ?? '').trim());
+      data.smoke = document.querySelector('input[name="smoke"]:checked')?.value ?? '';
+      if (!data.date) data.date = new Date().toLocaleDateString();
+
+      sessionStorage.setItem('tcc_prescription', JSON.stringify(data));
+      window.open('prescription.html', '_blank');
+    });
+  }
+})();

--- a/js/invoice.js
+++ b/js/invoice.js
@@ -557,10 +557,11 @@
   }
 
   // Hook up buttons
-  printBtn?.addEventListener('click', () => {
-    openReceipt(true);
+  // Ensure database save occurs before printing/downloading
+  printBtn?.addEventListener('click', async () => {
+    await openReceipt(true);
   });
-  downloadBtn?.addEventListener('click', () => {
-    openReceipt(false);
+  downloadBtn?.addEventListener('click', async () => {
+    await openReceipt(false);
   });
 })();

--- a/js/search.js
+++ b/js/search.js
@@ -209,6 +209,16 @@
       invList.appendChild(li);
     }
     detailEl.appendChild(invList);
+
+    // --- Edit button ---
+    if (patient.refNo) {
+      const editBtn = document.createElement('a');
+      editBtn.textContent = 'Edit Patient';
+      editBtn.className = 'btn btn-cta';
+      editBtn.style.marginTop = '12px';
+      editBtn.href = `edit_patient.html?refNo=${encodeURIComponent(patient.refNo)}`;
+      detailEl.appendChild(editBtn);
+    }
   }
 
   function renderResults(patients) {

--- a/pages/edit_patient.html
+++ b/pages/edit_patient.html
@@ -1,0 +1,303 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Tulsi Care Clinic – Edit Patient</title>
+  <!-- Pull the patient form stylesheet from the shared css folder -->
+  <link rel="stylesheet" href="../css/patient_form.css" />
+
+  <!-- Supabase client library (for database access) -->
+  <!--
+    NOTE: Replace the placeholders in patient_form.js with your own Supabase
+    project URL and anonymous API key. This script exposes a global
+    `supabase` object used by the JS to read/write patient records.
+  -->
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <!-- Initialize Supabase client with your project credentials.  See
+       js/supabase-client.js for configuration details. -->
+  <script src="../js/supabase-client.js"></script>
+</head>
+<body class="app-body">
+  <header class="app-header">
+    <div class="brand">
+      <div class="logo" aria-hidden="true"></div>
+      <div class="brand-text">
+        <h1>Tulsi Care Clinic</h1>
+        <p>Doctor Portal</p>
+      </div>
+    </div>
+    <nav class="nav-actions">
+      <a class="btn btn-outline" href="dashboard.html">Back to Dashboard</a>
+    </nav>
+  </header>
+
+  <main class="profile-layout">
+    <!-- LEFT: Persona / Basic Info -->
+    <aside class="persona card card--elevated">
+      <div class="persona-head">
+        <div class="avatar" aria-hidden="true"></div>
+        <div class="id-block">
+          <label for="refNo">Patient Ref #</label>
+          <!-- Reference number is auto-generated and read-only -->
+          <input id="refNo" placeholder="Auto-generated" readonly />
+        </div>
+      </div>
+
+      <div class="persona-section">
+        <div class="form-row">
+          <label for="name">Full Name</label>
+          <input id="name" placeholder="Full name" required />
+        </div>
+
+        <div class="split-2">
+          <div class="form-row">
+            <label for="age">Age</label>
+            <!-- Age is optional; removed required attribute -->
+            <input id="age" type="number" min="0" max="120" />
+          </div>
+          <div class="form-row">
+            <label for="date">Date</label>
+            <!-- Date is optional; removed required attribute -->
+            <input id="date" type="date" />
+          </div>
+        </div>
+
+        <!-- Cast field removed -->
+      </div>
+
+      <div class="persona-section">
+        <details class="collapsible" open>
+          <summary>Contact Details</summary>
+          <div class="form-row">
+            <label for="address">Address •</label>
+            <input id="address" placeholder="Street, City, Postcode" />
+          </div>
+          <div class="form-row">
+            <label for="mobile">Mobile no. •</label>
+            <!-- Mobile is optional; removed required attribute -->
+            <input id="mobile" placeholder="e.g., 0400 000 000" />
+          </div>
+        </details>
+      </div>
+
+      <p id="saveMsgTop" class="status" aria-live="polite"></p>
+    </aside>
+
+    <!-- RIGHT: Medical Information -->
+    <section class="medical card card--elevated">
+      <form id="patientForm" class="medical-form">
+        <!-- Labs / Vitals -->
+        <header class="section-head">
+          <h2>Labs & Vitals</h2>
+        </header>
+
+        <div class="grid g-4">
+          <div class="form-row unit">
+            <label for="fbs">FBS</label>
+            <input id="fbs" type="number" step="0.1" min="0" />
+            <span class="unit-tag">mg/dL</span>
+          </div>
+          <div class="form-row unit">
+            <label for="rbs">RBS</label>
+            <input id="rbs" type="number" step="0.1" min="0" />
+            <span class="unit-tag">mg/dL</span>
+          </div>
+          <div class="form-row unit">
+            <label for="bMealSugar">B. meal Sugar</label>
+            <input id="bMealSugar" type="number" step="0.1" min="0" />
+            <span class="unit-tag">mg/dL</span>
+          </div>
+          <div class="form-row unit">
+            <label for="bChol">B. Cholesterol</label>
+            <input id="bChol" type="number" step="0.1" min="0" />
+            <span class="unit-tag">mg/dL</span>
+          </div>
+
+          <div class="form-row unit">
+            <label for="ldl">LDL</label>
+            <input id="ldl" type="number" step="0.1" min="0" />
+            <span class="unit-tag">mg/dL</span>
+          </div>
+          <div class="form-row unit">
+            <label for="tg">TG</label>
+            <input id="tg" type="number" step="0.1" min="0" />
+            <span class="unit-tag">mg/dL</span>
+          </div>
+          <div class="form-row unit">
+            <label for="hdl">HDL</label>
+            <input id="hdl" type="number" step="0.1" min="0" />
+            <span class="unit-tag">mg/dL</span>
+          </div>
+          <div class="form-row">
+            <label for="bp">B.P</label>
+            <input id="bp" placeholder="e.g., 120/80" />
+          </div>
+
+          <div class="form-row unit">
+            <label for="sCreat">S. Creatinine</label>
+            <input id="sCreat" type="number" step="0.01" min="0" />
+            <span class="unit-tag">mg/dL</span>
+          </div>
+          <div class="form-row unit">
+            <label for="sUric">S. Uric Acid</label>
+            <input id="sUric" type="number" step="0.1" min="0" />
+            <span class="unit-tag">mg/dL</span>
+          </div>
+          <div class="form-row unit">
+            <label for="bmi">BMI</label>
+            <input id="bmi" type="number" step="0.1" min="0" />
+            <span class="unit-tag">kg/m²</span>
+          </div>
+          <div class="form-row unit">
+            <label for="spo2">SpO₂</label>
+            <input id="spo2" type="number" step="1" min="0" max="100" />
+            <span class="unit-tag">%</span>
+          </div>
+
+          <div class="form-row unit">
+            <label for="pulse">Pulse</label>
+            <input id="pulse" type="number" step="1" min="0" />
+            <span class="unit-tag">bpm</span>
+          </div>
+          <div class="form-row unit">
+            <label for="weight">Weight</label>
+            <input id="weight" type="number" step="0.1" min="0" />
+            <span class="unit-tag">kg</span>
+          </div>
+          <div class="form-row unit">
+            <label for="temp">Temp</label>
+            <input id="temp" type="text" placeholder="e.g., 37°C" />
+            <span class="unit-tag">°C</span>
+          </div>
+        </div>
+
+        <!-- History -->
+        <header class="section-head">
+          <h2>History</h2>
+        </header>
+
+        <div class="grid g-3">
+          <div class="history">
+            <label>H/O DM</label>
+            <div class="chips">
+              <input id="dmAbove" type="number" min="0" placeholder="Value" />
+              <select id="dmUnit">
+                <option>Days</option><option>Months</option><option>Years</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="history">
+            <label>H/O BP</label>
+            <div class="chips">
+              <input id="bpAbove" type="number" min="0" placeholder="Value" />
+              <select id="bpUnit">
+                <option>Days</option><option>Months</option><option>Years</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="history">
+            <label>K/C of Depression / Fits</label>
+            <div class="chips">
+              <input id="psychAbove" type="number" min="0" placeholder="Value" />
+              <select id="psychUnit">
+                <option>Days</option><option>Months</option><option>Years</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="history">
+            <label>Psychosis</label>
+            <div class="chips">
+              <input id="psychosisAbove" type="number" min="0" placeholder="Value" />
+              <select id="psychosisUnit">
+                <option>Days</option><option>Months</option><option>Years</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="history">
+            <label>K/C of CKD</label>
+            <div class="chips">
+              <input id="ckdAbove" type="number" min="0" placeholder="Value" />
+              <select id="ckdUnit">
+                <option>Days</option><option>Months</option><option>Years</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="history">
+            <label>Diabetic Foot</label>
+            <div class="chips">
+              <input id="dfAbove" type="number" min="0" placeholder="Value" />
+              <select id="dfUnit">
+                <option>Days</option><option>Months</option><option>Years</option>
+              </select>
+            </div>
+          </div>
+        </div>
+
+        <div class="grid g-2">
+          <div class="form-row">
+            <label for="others">Others •</label>
+            <input id="others" placeholder="Other conditions" />
+          </div>
+          <div class="form-row">
+            <label>Smoking</label>
+            <div class="radio-row">
+              <label><input type="radio" name="smoke" value="Smoker"> Smoker</label>
+              <label><input type="radio" name="smoke" value="Non smoker" checked> Non smoker</label>
+            </div>
+          </div>
+        </div>
+
+        <!-- Complaints / Drugs -->
+        <header class="section-head">
+          <h2>Complaints & Drugs</h2>
+        </header>
+
+        <div class="grid g-1">
+          <div class="form-row">
+            <label for="presentComplaint">Present complaint</label>
+            <textarea id="presentComplaint" rows="3" placeholder="Describe current complaint"></textarea>
+          </div>
+          <div class="form-row">
+            <label for="pastComplaint">Past complaints</label>
+            <textarea id="pastComplaint" rows="3" placeholder="Any past complaints"></textarea>
+          </div>
+          <div class="form-row">
+            <label for="hoDrugs">H/O taken Drugs</label>
+            <textarea id="hoDrugs" rows="3" placeholder="List previous drugs / duration"></textarea>
+          </div>
+        </div>
+
+        <div class="form-actions">
+          <button class="btn btn-success" type="submit">Save Patient</button>
+          <button class="btn btn-ghost" type="reset">Reset</button>
+          <button type="button" id="printPrescription" class="btn btn-outline">Print Prescription</button>
+        </div>
+
+        <p id="saveMsg" class="status" aria-live="polite"></p>
+      </form>
+    </section>
+  </main>
+
+  <footer class="site-foot">
+    <small>© <span id="year"></span> Tulsi Care Clinic. All rights reserved.</small>
+  </footer>
+
+  <!-- Load the patient form controller from the parent js folder -->
+  <script src="../js/edit_patient.js"></script>
+
+  <!-- Minimal print handler moved to patient_form.js; the inline version has been removed to avoid duplication -->
+
+  <!-- Simple auth guard: redirect unauthenticated users to the root login -->
+  <script>
+    if (sessionStorage.getItem('auth') !== 'true') {
+      window.location.replace('../index.html');
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated page and controller for editing existing patients
- offer edit button in patient search results
- prompt to edit when patient already exists
- ensure invoices save before printing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b314cf72948327a832978e60be0f43