### PR TITLE
Reset forms and add refresh controls

### DIFF
--- a/js/edit_patient.js
+++ b/js/edit_patient.js
@@ -195,9 +195,11 @@
         const idx = list.findIndex(p => p.refNo === refNo);
         if (idx !== -1) {
           list[idx] = { ...list[idx], ...payload, refNo };
-          setPatients(list);
-          saved = true;
+        } else {
+          list.push({ ...payload, refNo });
         }
+        setPatients(list);
+        saved = true;
       }
 
       if (saved && msg) {

--- a/js/invoice.js
+++ b/js/invoice.js
@@ -17,6 +17,8 @@
   const printBtn    = document.getElementById('printPage');
   const resetBtn    = document.getElementById('resetForm');
   const downloadBtn = document.getElementById('downloadPdf');
+  const form        = document.getElementById('invoiceForm');
+  const refreshBtn  = document.getElementById('refreshPage');
   // Status message element to show validation errors or success messages
   const msg         = document.getElementById('msg');
   const patientListEl = document.getElementById('patientList');
@@ -183,6 +185,7 @@
 
   // Initialize meta and restore draft/patients on load
   function init() {
+    form?.reset();
     ensureMeta();
     loadDraft();
     const last = localStorage.getItem('LAST_PATIENT');
@@ -193,6 +196,9 @@
         selectedPatientRef = p.refNo || null;
       } catch {}
       localStorage.removeItem('LAST_PATIENT');
+    } else {
+      receivedEl.value = '';
+      selectedPatientRef = null;
     }
     loadPatients().then(() => {
       matchPatientName(receivedEl.value.trim());
@@ -216,7 +222,12 @@
     }, 0);
   });
 
-  window.addEventListener('beforeunload', saveDraft);
+  refreshBtn?.addEventListener('click', () => {
+    clearDraft();
+    window.location.reload();
+  });
+
+  // Removed automatic draft saving to keep form blank when revisiting
 
   receivedEl?.addEventListener('input', () => {
     matchPatientName(receivedEl.value.trim());
@@ -550,9 +561,13 @@
     }
     if (autoPrint) {
       await generateReceiptPdf(payload, true);
-      return;
+    } else {
+      await generateReceiptPdf(payload, false);
     }
-    await generateReceiptPdf(payload, false);
+    form?.reset();
+    ensureMeta();
+    receivedEl.value = '';
+    selectedPatientRef = null;
     clearDraft();
   }
 

--- a/js/patient_form.js
+++ b/js/patient_form.js
@@ -15,6 +15,7 @@
 
   const form = document.getElementById('patientForm');
   const msg  = document.getElementById('saveMsg');
+  form?.reset();
   // Set the date input default to today's date if not already set.
   const dateInput = document.getElementById('date');
   if (dateInput && !dateInput.value) {
@@ -40,6 +41,9 @@
 
   // Immediately populate the ref number when the form is loaded
   generateAndSetRef();
+
+  const refreshBtn = document.getElementById('refreshPage');
+  refreshBtn?.addEventListener('click', () => window.location.reload());
 
   const params = new URLSearchParams(window.location.search);
   const returnTo = params.get('from');

--- a/pages/invoice.html
+++ b/pages/invoice.html
@@ -39,6 +39,7 @@
     </div>
     <nav class="nav-actions">
       <a class="btn btn-outline" href="dashboard.html">Back to Dashboard</a>
+      <button type="button" id="refreshPage" class="btn btn-ghost">Refresh</button>
     </nav>
   </header>
 

--- a/pages/patient_form.html
+++ b/pages/patient_form.html
@@ -29,6 +29,7 @@
     </div>
     <nav class="nav-actions">
       <a class="btn btn-outline" href="dashboard.html">Back to Dashboard</a>
+      <button type="button" id="refreshPage" class="btn btn-ghost">Refresh</button>
     </nav>
   </header>
 


### PR DESCRIPTION
## Summary
- Ensure edited patient records persist by updating or inserting offline storage entries.
- Add refresh buttons on patient creation and invoice pages with handlers to reload the page.
- Clear invoice drafts and reset fields after generating a receipt to avoid stale data.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3178578f48327b216d39ed1e54d9b